### PR TITLE
[feat] craco setting 및 path alias 적용 (#1)

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,15 @@
+const cracoAlias = require("craco-alias");
+
+module.exports = {
+    plugins: [
+        {
+            plugin: cracoAlias,
+            options: {
+                source: "tsconfig",
+                baseUrl: ".",
+                tsConfigPath: "tsconfig.paths.json",
+                debug: false
+            }
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,10 @@
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
         "zustand": "^4.5.1"
+      },
+      "devDependencies": {
+        "@craco/craco": "^7.1.0",
+        "craco-alias": "^3.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2027,6 +2031,52 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@craco/craco": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
+      "integrity": "sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==",
+      "dev": true,
+      "dependencies": {
+        "autoprefixer": "^10.4.12",
+        "cosmiconfig": "^7.0.1",
+        "cosmiconfig-typescript-loader": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.7",
+        "webpack-merge": "^5.8.0"
+      },
+      "bin": {
+        "craco": "dist/bin/craco.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "react-scripts": "^5.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -4009,6 +4059,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -5988,6 +6062,20 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6227,6 +6315,38 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+      "integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.7.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/craco-alias": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/craco-alias/-/craco-alias-3.0.1.tgz",
+      "integrity": "sha512-N+Qaf/Gr/f3o5ZH2TQjMu5NhR9PnT1ZYsfejpNvZPpB0ujdrhsSr4Ct6GVjnV5ostCVquhTKJpIVBKyL9qDQYA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6894,6 +7014,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -8346,6 +8475,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -9661,6 +9799,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -9828,6 +9978,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -12317,6 +12476,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -15782,6 +15947,18 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -16889,6 +17066,64 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -17264,6 +17499,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -17630,6 +17871,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -17806,6 +18061,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -18294,6 +18555,15 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "zustand": "^4.5.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
+    "eject": "craco eject",
     "typecheck": "tsc --noEmit --skiplibCheck"
   },
   "eslintConfig": {
@@ -49,5 +49,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@craco/craco": "^7.1.0",
+    "craco-alias": "^3.0.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,22 @@
-import Layout from "./components/layout/Layout";
-import Home from "./pages/Home";
-import { BookStoreThemeProvider } from "./context/themeContext";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
-import Error from "./components/common/Error";
-import SignUp from "./pages/Signup";
-import SignUpForm from "./components/form/SignUpForm";
-import ResetPassword from "./pages/ResetPassword";
-import ResetPasswordForm from "./components/form/ResetPasswordForm";
-import Login from "./pages/Login";
-import LoginForm from "./components/form/LoginForm";
-import BookDetail from "./pages/Book/BookDetail";
-import BookIndex from "./pages/Book";
-import Book from "./pages/Book/Book";
-import Cart from "./pages/Cart";
-import Order from "./pages/Order";
-import OrderList from "./pages/OrderList";
+
+import { BookStoreThemeProvider } from "@/context/themeContext";
+
+import Error from "@/components/common/Error";
+import LoginForm from "@/components/form/LoginForm";
+import SignUpForm from "@/components/form/SignUpForm";
+import ResetPasswordForm from "@/components/form/ResetPasswordForm";
+
+import Home from "@/pages/Home";
+import Login from "@/pages/user_page/Login";
+import SignUp from "@/pages/user_page/SignUp";
+import ResetPassword from "@/pages/user_page/ResetPassword";
+import Book from "@/pages/book_page/Book";
+import BookIndex from "@/pages/book_page";
+import BookDetail from "@/pages/book_page/BookDetail";
+import Cart from "@/pages/cart_page/Cart";
+import Order from "@/pages/order_page/Order";
+import OrderList from "@/pages/order_page/OrderList";
 
 const router = createBrowserRouter([
   {

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,5 +1,5 @@
-import { SignUpProps } from "../components/form/SignUpForm";
-import { httpClient } from "./http";
+import { httpClient } from "@/api/http";
+import { SignUpProps } from "@/components/form/SignUpForm";
 
 export const signUp = async (userData: SignUpProps) => {
   const response = await httpClient.post("/users/join", userData);

--- a/src/api/book.api.ts
+++ b/src/api/book.api.ts
@@ -1,7 +1,6 @@
-import { NumberLiteralType } from "typescript";
-import { httpClient } from "./http";
-import { Book, BookDetail } from "../models/book.model";
-import { Pagination } from "../models/pagination.model";
+import { httpClient } from "@/api/http";
+import { Book, BookDetail } from "@/models/book.model";
+import { Pagination } from "@/models/pagination.model";
 
 interface FetchBooksPrams {
   categoryId?: number;

--- a/src/api/carts.api.ts
+++ b/src/api/carts.api.ts
@@ -1,5 +1,5 @@
-import { Cart } from "../models/cart.model";
-import { httpClient } from "./http";
+import { httpClient } from "@/api/http";
+import { Cart } from "@/models/cart.model";
 
 interface AddToCartProps {
   bookId: number;

--- a/src/api/category.api.ts
+++ b/src/api/category.api.ts
@@ -1,4 +1,4 @@
-import { httpClient } from "./http";
+import { httpClient } from "@/api/http";
 
 export const fetchCategory = async () => {
   try {

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { getToken, removeToken } from "../store/authStore";
+import { getToken, removeToken } from "@/store/authStore";
 
 const BASE_URL = "http://localhost:8000";
 const DEFAULT_TIMEOUT = 30000;

--- a/src/api/order.api.ts
+++ b/src/api/order.api.ts
@@ -1,5 +1,5 @@
-import { Order, OrderDetailItem, OrderSheet } from "../models/order.model";
-import { httpClient } from "./http";
+import { httpClient } from "@/api/http";
+import { Order, OrderDetailItem, OrderSheet } from "@/models/order.model";
 
 export const order = async (orderData: OrderSheet) => {
   const response = await httpClient.post("/orders", orderData);

--- a/src/components/Button/FindAddressButton.tsx
+++ b/src/components/Button/FindAddressButton.tsx
@@ -1,6 +1,7 @@
-import { styled } from "styled-components";
-import Button from "../common/Button";
 import { useEffect } from "react";
+import { styled } from "styled-components";
+
+import Button from "@/components/common/Button";
 
 interface Props {
   onCompleted: (address: string) => void;

--- a/src/components/Button/Like.tsx
+++ b/src/components/Button/Like.tsx
@@ -1,7 +1,9 @@
 import styled from "styled-components";
-import { BookDetail } from "../../models/book.model";
-import Button from "../common/Button";
+
+import { BookDetail } from "@/models/book.model";
+
 import { FaHeart } from "react-icons/fa";
+import Button from "@/components/common/Button";
 
 interface Props {
   book: BookDetail;

--- a/src/components/books/AddToCart.tsx
+++ b/src/components/books/AddToCart.tsx
@@ -1,10 +1,12 @@
-import { styled } from "styled-components";
-import { BookDetail } from "../../models/book.model";
-import InputText from "../common/InputText";
-import Button from "../common/Button";
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { useCart } from "../../hooks/useCart";
+import { styled } from "styled-components";
+
+import { BookDetail } from "@/models/book.model";
+import { useCart } from "@/hooks/useCart";
+
+import InputText from "@/components/common/InputText";
+import Button from "@/components/common/Button";
 
 interface Props {
   book: BookDetail;

--- a/src/components/books/BooksEmpty.tsx
+++ b/src/components/books/BooksEmpty.tsx
@@ -1,6 +1,7 @@
-import { FaSmileWink } from "react-icons/fa";
 import { Link } from "react-router-dom";
-import Empty from "../common/Empty";
+
+import { FaSmileWink } from "react-icons/fa";
+import Empty from "@/components/common/Empty";
 
 export default function BooksEmpty() {
   return (

--- a/src/components/books/BooksFilter.tsx
+++ b/src/components/books/BooksFilter.tsx
@@ -1,8 +1,10 @@
 import { styled } from "styled-components";
-import { useCategory } from "../../hooks/useCategory";
-import Button from "../common/Button";
 import { useSearchParams } from "react-router-dom";
-import { QUERYSTRING } from "../../constants/querystring";
+
+import { useCategory } from "@/hooks/useCategory";
+import { QUERYSTRING } from "@/constants/querystring";
+
+import Button from "@/components/common/Button";
 
 export default function BooksFilter() {
   const { category } = useCategory();

--- a/src/components/books/BooksItem.tsx
+++ b/src/components/books/BooksItem.tsx
@@ -1,10 +1,13 @@
-import { styled } from "styled-components";
-import { Book } from "../../models/book.model";
-import { getImgSrc } from "../../utils/image";
-import { formatNumber } from "../../utils/format";
-import { FaHeart } from "react-icons/fa";
-import { ViewMode } from "./BooksViewSwitcher";
 import { Link } from "react-router-dom";
+import { styled } from "styled-components";
+
+import { Book } from "@/models/book.model";
+
+import { getImgSrc } from "@/utils/image";
+import { formatNumber } from "@/utils/format";
+
+import { FaHeart } from "react-icons/fa";
+import { ViewMode } from "@/components/books/BooksViewSwitcher";
 
 interface BookItemProps {
   book: Book;

--- a/src/components/books/BooksList.tsx
+++ b/src/components/books/BooksList.tsx
@@ -1,10 +1,13 @@
-import { styled } from "styled-components";
-import BooksItem from "./BooksItem";
-import { Book } from "../../models/book.model";
-import { useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { QUERYSTRING } from "../../constants/querystring";
-import { ViewMode } from "./BooksViewSwitcher";
+import { useLocation } from "react-router-dom";
+import { styled } from "styled-components";
+
+import { Book } from "@/models/book.model";
+
+import { QUERYSTRING } from "@/constants/querystring";
+
+import BooksItem from "@/components/books/BooksItem";
+import { ViewMode } from "@/components/books/BooksViewSwitcher";
 
 interface Props {
   books: Book[];

--- a/src/components/books/BooksViewSwitcher.tsx
+++ b/src/components/books/BooksViewSwitcher.tsx
@@ -1,9 +1,11 @@
-import { styled } from "styled-components";
-import Button from "../common/Button";
-import { FaList, FaTh } from "react-icons/fa";
-import { useSearchParams } from "react-router-dom";
-import { QUERYSTRING } from "../../constants/querystring";
 import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { styled } from "styled-components";
+
+import { QUERYSTRING } from "@/constants/querystring";
+
+import { FaList, FaTh } from "react-icons/fa";
+import Button from "../common/Button";
 
 const viewOptions = [
   {

--- a/src/components/books/Pagination.tsx
+++ b/src/components/books/Pagination.tsx
@@ -1,9 +1,12 @@
-import { styled } from "styled-components";
-import { Pagination as IPagination } from "../../models/pagination.model";
-import { LIMIT } from "../../constants/pagination";
-import Button from "../common/Button";
 import { useSearchParams } from "react-router-dom";
-import { QUERYSTRING } from "../../constants/querystring";
+import { styled } from "styled-components";
+
+import { Pagination as IPagination } from "../../models/pagination.model";
+
+import { LIMIT } from "@/constants/pagination";
+import { QUERYSTRING } from "@/constants/querystring";
+
+import Button from "@/components/common/Button";
 
 interface Props {
   pagination: IPagination;

--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -1,11 +1,14 @@
-import styled from "styled-components";
-import { Cart } from "../../models/cart.model";
-import Button from "../common/Button";
-import Title from "../common/Title";
-import { formatNumber } from "../../utils/format";
-import CheckIconButton from "./CheckIconButton";
 import { useMemo } from "react";
-import { useAlert } from "../../hooks/useAlert";
+import styled from "styled-components";
+
+import { Cart } from "@/models/cart.model";
+
+import { useAlert } from "@/hooks/useAlert";
+import { formatNumber } from "@/utils/format";
+
+import Title from "@/components/common/Title";
+import Button from "@/components/common/Button";
+import CheckIconButton from "@/components/cart/CheckIconButton";
 
 interface Props {
   cart: Cart;

--- a/src/components/cart/CartSummary.tsx
+++ b/src/components/cart/CartSummary.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
-import { formatNumber } from "../../utils/format";
+
+import { formatNumber } from "@/utils/format";
 
 interface Props {
   totalAmount: number;

--- a/src/components/cart/CheckIconButton.tsx
+++ b/src/components/cart/CheckIconButton.tsx
@@ -1,5 +1,6 @@
-import { FaRegCheckCircle, FaRegCircle } from "react-icons/fa";
 import styled from "styled-components";
+
+import { FaRegCheckCircle, FaRegCircle } from "react-icons/fa";
 
 interface Props {
   isChecked: boolean;

--- a/src/components/common/Button.spec.tsx
+++ b/src/components/common/Button.spec.tsx
@@ -1,6 +1,7 @@
 import { logRoles, render, screen } from "@testing-library/react";
-import Button from "./Button";
-import { BookStoreThemeProvider } from "../../context/themeContext";
+
+import { BookStoreThemeProvider } from "@/context/themeContext";
+import Button from "@/components/common/Button";
 
 describe("Title 컴포넌트 테스트", () => {
   it("렌더 확인", () => {

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
-import { ButtonSchema, ButtonSize } from "../../style/theme";
+
+import { ButtonSchema, ButtonSize } from "@/style/theme";
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;

--- a/src/components/common/EllipsisBox.tsx
+++ b/src/components/common/EllipsisBox.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import styled from "styled-components";
-import Button from "./Button";
+
 import { FaAngleDown } from "react-icons/fa";
+import Button from "@/components/common/Button";
 
 interface Props {
   children: React.ReactNode;

--- a/src/components/common/Empty.tsx
+++ b/src/components/common/Empty.tsx
@@ -1,6 +1,6 @@
-import { FaSmileWink } from "react-icons/fa";
 import { styled } from "styled-components";
-import Title from "../common/Title";
+
+import Title from "@/components/common/Title";
 
 interface Props {
   icon?: React.ReactNode;

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,5 +1,6 @@
 import { styled } from "styled-components";
-import logo from "../../assets/images/logo.png";
+
+import logo from "@/assets/images/logo.png";
 
 export default function Footer() {
   return (

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,12 +1,13 @@
-import { styled } from "styled-components";
-import ThemeSwitcher from "../header/ThemeSwitcher";
-import logo from "../../assets/images/logo.png";
-import { FaSignInAlt, FaRegUser } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import { styled } from "styled-components";
 
-import { useCategory } from "../../hooks/useCategory";
-import { useAuthStore } from "../../store/authStore";
-import Button from "./Button";
+import { useAuthStore } from "@/store/authStore";
+import { useCategory } from "@/hooks/useCategory";
+
+import logo from "@/assets/images/logo.png";
+
+import { FaSignInAlt, FaRegUser } from "react-icons/fa";
+import ThemeSwitcher from "@/components/header/ThemeSwitcher";
 
 export default function Header() {
   const { category } = useCategory();

--- a/src/components/common/InputText.spec.tsx
+++ b/src/components/common/InputText.spec.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import InputText from "./InputText";
-import { BookStoreThemeProvider } from "../../context/themeContext";
+
+import { BookStoreThemeProvider } from "@/context/themeContext";
+import InputText from "@/components/common/InputText";
 
 describe("Title 컴포넌트 테스트", () => {
   it("렌더 확인", () => {

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,5 +1,6 @@
 import { styled } from "styled-components";
-import { ColorKey, HeadingSize } from "../../style/theme";
+
+import { ColorKey, HeadingSize } from "@/style/theme";
 
 interface TitleProps {
   children: React.ReactNode;

--- a/src/components/form/LoginForm.tsx
+++ b/src/components/form/LoginForm.tsx
@@ -1,11 +1,14 @@
 import { useNavigate } from "react-router-dom";
-import Button from "../common/Button";
-import InputText from "../common/InputText";
-import { useAlert } from "../../hooks/useAlert";
 import { useForm } from "react-hook-form";
-import { login } from "../../api/auth.api";
-import { SignUpStyle } from "./SignUpForm";
-import { useAuthStore } from "../../store/authStore";
+
+import { login } from "@/api/auth.api";
+
+import { useAuthStore } from "@/store/authStore";
+import { useAlert } from "@/hooks/useAlert";
+
+import Button from "@/components/common/Button";
+import { SignUpStyle } from "@/components/form/SignUpForm";
+import InputText from "@/components/common/InputText";
 
 export interface SignUpProps {
   email: string;

--- a/src/components/form/ResetPasswordForm.tsx
+++ b/src/components/form/ResetPasswordForm.tsx
@@ -1,11 +1,14 @@
-import { useNavigate } from "react-router-dom";
-import Button from "../common/Button";
-import InputText from "../common/InputText";
-import { useAlert } from "../../hooks/useAlert";
-import { useForm } from "react-hook-form";
-import { resetPassword, resetRequest } from "../../api/auth.api";
-import { SignUpStyle } from "./SignUpForm";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+import { resetPassword, resetRequest } from "@/api/auth.api";
+
+import { useAlert } from "@/hooks/useAlert";
+
+import Button from "@/components/common/Button";
+import { SignUpStyle } from "@/components/form/SignUpForm";
+import InputText from "@/components/common/InputText";
 
 export interface SignUpProps {
   email: string;

--- a/src/components/form/SignUpForm.tsx
+++ b/src/components/form/SignUpForm.tsx
@@ -1,10 +1,12 @@
 import { Link, useNavigate } from "react-router-dom";
-import Button from "../common/Button";
-import InputText from "../common/InputText";
-import { useAlert } from "../../hooks/useAlert";
 import { useForm } from "react-hook-form";
-import { signUp } from "../../api/auth.api";
 import { styled } from "styled-components";
+
+import { signUp } from "@/api/auth.api";
+import { useAlert } from "@/hooks/useAlert";
+
+import Button from "@/components/common/Button";
+import InputText from "@/components/common/InputText";
 
 export interface SignUpProps {
   email: string;

--- a/src/components/header/ThemeSwitcher.tsx
+++ b/src/components/header/ThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
-import { ThemeName } from "../../style/theme";
-import { ThemeContext } from "../../context/themeContext";
+
+import { ThemeName } from "@/style/theme";
+import { ThemeContext } from "@/context/themeContext";
 
 interface Props {
   themeName: ThemeName;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { styled } from "styled-components";
-import Footer from "../common/Footer";
-import Header from "../common/Header";
+
+import Footer from "@/components/common/Footer";
+import Header from "@/components/common/Header";
 
 interface LayoutProps {
   children: React.ReactNode;

--- a/src/context/themeContext.tsx
+++ b/src/context/themeContext.tsx
@@ -1,7 +1,8 @@
 import { ReactNode, createContext, useEffect, useState } from "react";
-import { ThemeName, getTheme } from "../style/theme";
 import { ThemeProvider } from "styled-components";
-import { GlobalStyle } from "../style/global";
+
+import { GlobalStyle } from "@/style/global";
+import { ThemeName, getTheme } from "@/style/theme";
 
 const DEFAULT_THEME_NAME = "light";
 const THEME_LOCAL_STORAGE_KEY = "book_store_theme";

--- a/src/hooks/useBook.ts
+++ b/src/hooks/useBook.ts
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
-import { BookDetail } from "../models/book.model";
-import { fetchBook, likeBook, unLikeBook } from "../api/book.api";
-import { useAlert } from "./useAlert";
-import { useAuthStore } from "../store/authStore";
+
+import { BookDetail } from "@/models/book.model";
+import { useAuthStore } from "@/store/authStore";
+
+import { fetchBook, likeBook, unLikeBook } from "@/api/book.api";
+
+import { useAlert } from "@/hooks/useAlert";
 
 export const useBook = (bookId: string | undefined) => {
   const [book, setBook] = useState<BookDetail | null>(null);

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Book } from "../models/book.model";
-import { Pagination } from "../models/pagination.model";
-import { fetchBooks } from "../api/book.api";
-import { QUERYSTRING } from "../constants/querystring";
-import { LIMIT } from "../constants/pagination";
+
+import { Book } from "@/models/book.model";
+import { Pagination } from "@/models/pagination.model";
+
+import { fetchBooks } from "@/api/book.api";
+
+import { LIMIT } from "@/constants/pagination";
+import { QUERYSTRING } from "@/constants/querystring";
 
 export const useBooks = () => {
   const location = useLocation();

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
-import { useAlert } from "./useAlert";
-import { addToCarts, deleteToCarts, fetchCarts } from "../api/carts.api";
-import { Cart } from "../models/cart.model";
+
+import { Cart } from "@/models/cart.model";
+
+import { addToCarts, deleteToCarts, fetchCarts } from "@/api/carts.api";
+
+import { useAlert } from "@/hooks/useAlert";
 
 export const useCart = (bookId?: number) => {
   const [cartAdded, setCartAdded] = useState<boolean>(false);

--- a/src/hooks/useCategory.ts
+++ b/src/hooks/useCategory.ts
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
-import { Category } from "../models/category.model";
-import { fetchCategory } from "../api/category.api";
 import { useLocation } from "react-router-dom";
-import { QUERYSTRING } from "../constants/querystring";
+
+import { Category } from "@/models/category.model";
+
+import { fetchCategory } from "@/api/category.api";
+
+import { QUERYSTRING } from "@/constants/querystring";
 
 export const useCategory = () => {
   const location = useLocation();

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
-import { OrderListItem } from "../models/order.model";
-import { fetchOrderDetail, fetchOrders, order } from "../api/order.api";
+
+import { OrderListItem } from "@/models/order.model";
+
+import { fetchOrderDetail, fetchOrders } from "@/api/order.api";
 
 export const useOrders = () => {
   const [orders, setOrders] = useState<OrderListItem[]>([]);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
+
+import App from "@/App";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,12 @@
-import { FaHeart } from "react-icons/fa";
-import Button from "../components/common/Button";
-import InputText from "../components/common/InputText";
-import Title from "../components/common/Title";
-import Layout from "../components/layout/Layout";
-import { formatNumber } from "../utils/format";
 import styled from "styled-components";
+
+import { formatNumber } from "@/utils/format";
+
+import { FaHeart } from "react-icons/fa";
+import Title from "@/components/common/Title";
+import Layout from "@/components/layout/Layout";
+import Button from "@/components/common/Button";
+import InputText from "@/components/common/InputText";
 
 export default function Home() {
   return (

--- a/src/pages/book_page/Book.tsx
+++ b/src/pages/book_page/Book.tsx
@@ -1,11 +1,13 @@
 import { styled } from "styled-components";
-import Title from "../../components/common/Title";
-import BooksFilter from "../../components/books/BooksFilter";
-import BooksViewSwitcher from "../../components/books/BooksViewSwitcher";
-import BooksList from "../../components/books/BooksList";
-import BooksEmpty from "../../components/books/BooksEmpty";
-import Pagination from "../../components/books/Pagination";
-import { useBooks } from "../../hooks/useBooks";
+
+import { useBooks } from "@/hooks/useBooks";
+
+import Title from "@/components/common/Title";
+import BooksList from "@/components/books/BooksList";
+import Pagination from "@/components/books/Pagination";
+import BooksEmpty from "@/components/books/BooksEmpty";
+import BooksFilter from "@/components/books/BooksFilter";
+import BooksViewSwitcher from "@/components/books/BooksViewSwitcher";
 
 export default function Book() {
   const { books, pagination, isEmpty } = useBooks();

--- a/src/pages/book_page/BookDetail.tsx
+++ b/src/pages/book_page/BookDetail.tsx
@@ -1,15 +1,17 @@
+import { Link, useParams } from "react-router-dom";
 import { styled } from "styled-components";
-import Layout from "../../components/layout/Layout";
-import { useParams } from "react-router-dom";
-import { useBook } from "../../hooks/useBook";
-import { getImgSrc } from "../../utils/image";
-import Title from "../../components/common/Title";
-import { BookDetail as IBookDetail } from "../../models/book.model";
-import { formatDate, formatNumber } from "../../utils/format";
-import { Link } from "react-router-dom";
-import EllipsisBox from "../../components/common/EllipsisBox";
-import Like from "../../components/Button/Like";
-import AddToCart from "../../components/books/AddToCart";
+
+import { BookDetail as IBookDetail } from "@/models/book.model";
+
+import { getImgSrc } from "@/utils/image";
+import { formatDate, formatNumber } from "@/utils/format";
+
+import { useBook } from "@/hooks/useBook";
+
+import Like from "@/components/button/Like";
+import Title from "@/components/common/Title";
+import AddToCart from "@/components/books/AddToCart";
+import EllipsisBox from "@/components/common/EllipsisBox";
 
 const bookInfoList = [
   {

--- a/src/pages/book_page/index.tsx
+++ b/src/pages/book_page/index.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router-dom";
-import Layout from "../../components/layout/Layout";
+import Layout from "@/components/layout/Layout";
 
 export default function BookIndex() {
   return (

--- a/src/pages/cart_page/Cart.tsx
+++ b/src/pages/cart_page/Cart.tsx
@@ -1,16 +1,20 @@
-import { styled } from "styled-components";
-import Title from "../components/common/Title";
-import Layout from "../components/layout/Layout";
-import CartItem from "../components/cart/CartItem";
-import { useCart } from "../hooks/useCart";
 import { useMemo, useState } from "react";
-import Empty from "../components/common/Empty";
-import { FaShoppingCart } from "react-icons/fa";
-import CartSummary from "../components/cart/CartSummary";
-import Button from "../components/common/Button";
-import { useAlert } from "../hooks/useAlert";
-import { OrderSheet } from "../models/order.model";
 import { useNavigate } from "react-router-dom";
+
+import { styled } from "styled-components";
+
+import { OrderSheet } from "@/models/order.model";
+
+import { useCart } from "@/hooks/useCart";
+import { useAlert } from "@/hooks/useAlert";
+
+import { FaShoppingCart } from "react-icons/fa";
+import Title from "@/components/common/Title";
+import Empty from "@/components/common/Empty";
+import Layout from "@/components/layout/Layout";
+import Button from "@/components/common/Button";
+import CartItem from "@/components/cart/CartItem";
+import CartSummary from "@/components/cart/CartSummary";
 
 export default function Cart() {
   const { carts, deleteCartItem, isEmpty } = useCart();

--- a/src/pages/order_page/Order.tsx
+++ b/src/pages/order_page/Order.tsx
@@ -1,16 +1,21 @@
-import { styled } from "styled-components";
-import Layout from "../components/layout/Layout";
 import { useLocation, useNavigate } from "react-router-dom";
-import Title from "../components/common/Title";
-import CartSummary from "../components/cart/CartSummary";
-import Button from "../components/common/Button";
-import { CartStyle } from "./Cart";
-import InputText from "../components/common/InputText";
 import { useForm } from "react-hook-form";
-import { Delivery, OrderSheet } from "../models/order.model";
-import FindAddressButton from "../components/Button/FindAddressButton";
-import { order } from "../api/order.api";
-import { useAlert } from "../hooks/useAlert";
+import { styled } from "styled-components";
+
+import { Delivery, OrderSheet } from "@/models/order.model";
+
+import { order } from "@/api/order.api";
+
+import { useAlert } from "@/hooks/useAlert";
+
+import { CartStyle } from "@/pages/cart_page/Cart";
+
+import Title from "@/components/common/Title";
+import Button from "@/components/common/Button";
+import Layout from "@/components/layout/Layout";
+import InputText from "@/components/common/InputText";
+import CartSummary from "@/components/cart/CartSummary";
+import FindAddressButton from "@/components/button/FindAddressButton";
 
 interface DeliveryForm extends Delivery {
   addressDetail: string;

--- a/src/pages/order_page/OrderList.tsx
+++ b/src/pages/order_page/OrderList.tsx
@@ -1,15 +1,16 @@
-import { styled } from "styled-components";
-import Title from "../components/common/Title";
-import Layout from "../components/layout/Layout";
-import { useOrders } from "../hooks/useOrders";
-import { formatNumber, formatDate } from "../utils/format";
-import Button from "../components/common/Button";
 import { Fragment } from "react";
+import { styled } from "styled-components";
+
+import { formatNumber, formatDate } from "@/utils/format";
+
+import { useOrders } from "@/hooks/useOrders";
+
+import Title from "@/components/common/Title";
+import Button from "@/components/common/Button";
+import Layout from "@/components/layout/Layout";
 
 export default function OrderList() {
   const { orders, selectOrderItem, selectedItemId } = useOrders();
-
-  console.log(orders);
 
   return (
     <Layout>

--- a/src/pages/user_page/Login.tsx
+++ b/src/pages/user_page/Login.tsx
@@ -1,6 +1,7 @@
-import Title from "../components/common/Title";
 import { Outlet } from "react-router-dom";
-import Layout from "../components/layout/Layout";
+
+import Title from "@/components/common/Title";
+import Layout from "@/components/layout/Layout";
 
 export default function Login() {
   return (

--- a/src/pages/user_page/ResetPassword.tsx
+++ b/src/pages/user_page/ResetPassword.tsx
@@ -1,6 +1,7 @@
-import Title from "../components/common/Title";
 import { Outlet } from "react-router-dom";
-import Layout from "../components/layout/Layout";
+
+import Title from "@/components/common/Title";
+import Layout from "@/components/layout/Layout";
 
 export default function ResetPassword() {
   return (

--- a/src/pages/user_page/Signup.tsx
+++ b/src/pages/user_page/Signup.tsx
@@ -1,6 +1,7 @@
-import Title from "../components/common/Title";
 import { Outlet } from "react-router-dom";
-import Layout from "../components/layout/Layout";
+
+import Title from "@/components/common/Title";
+import Layout from "@/components/layout/Layout";
 
 export default function SignUp() {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
+  "extends": "./tsconfig.paths.json",
   "include": [
-    "src"
-  ]
+    "src", "craco.config.js"
+  ],
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["src/*"]
+        }
+    }
+}


### PR DESCRIPTION
* feat: craco 설치 후 스크립트 적용 및 구동 테스트 완료

* feat: api 폴더 내에 path-alias 적용

* feat: component 내 Books 폴더 내 컴포넌트 path-alias 적용

* feat: 폴더 이름 변경

* feat: component 내 button 폴더 내 컴포넌트 path-alias 적용

* feat: cart 컴포넌트들 path-alias 적용

* feat: 공통 컴포넌트 path-alias 적용

* feat: 컴포넌트 내 파일 path-alias 적용

* feat: context, hooks 내 path-alias 적용

* feat: pages 폴더 내 path-alias 적용

* feat: App 컴포넌트와 index 컴포넌트 path-alias 적용